### PR TITLE
Add "amqplib" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "101": "^1.2.0",
+    "amqplib": "^0.4.0",
     "assert-args": "^1.0.3",
     "callsite": "^1.0.0",
     "co": "^4.6.0",


### PR DESCRIPTION
amqplib is needed by coworkers to run, shouldn't it be a dependency ?