### PR TITLE
Example typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ app.on('error', function (err, context) {
     let message = context.message
     let requeue = false
     // nack the message
-    channel.nack(message, requeue)
+    channel.nack(message, false, requeue)
   }
 })
 ```


### PR DESCRIPTION
According to [amqlib doc](http://www.squaremobius.net/amqp.node/channel_api.html#channel_nack), the requeue argument should be on the third position (tried and it works, was requeued with the example because reque is true by default).